### PR TITLE
Add puppeteer-lambda type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,9 @@ Run `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install puppeteer-lambda`, deploy
 ## Q&A  
 ### Why not use `puppeteer-core`?  
 In development mode ,we still need chromnium for debugging , so better to `puppeteer` which will install chromnium automatically  
+
+### How do we use `puppeteer-lambda` with TypeScript?
+`puppeteer-lambda` type definitions depends on `@types/puppeteer` definition.
+You must add `@types/puppeteer` in your project.
+
+`npm install @types/puppeteer`

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,2 @@
+import { Browser, LaunchOptions } from 'puppeteer';
+export declare function getBrowser(options?: LaunchOptions): Promise<Browser>;


### PR DESCRIPTION
Hi, thank you for the awesome library!

It is difficult to use in TypeScript without type definition for `puppeter-lambda`.
So I added a type definition.

When developing with TypeScript, you need to add `@types/puppeteer` to dependency.
So I wrote about it in the README.

Thank you.
